### PR TITLE
Split the recourse_adapter.py file into multiple files.

### DIFF
--- a/data/adapters/categorical_adapter.py
+++ b/data/adapters/categorical_adapter.py
@@ -36,8 +36,8 @@ class OneHotAdapter(recourse_adapter.RecourseAdapter):
         self.continuous_features = continuous_features
         self.label = label
 
-        self.sc_dict: Mapping[str, StandardScaler] = None
-        self.ohe_dict: Mapping[str, OneHotEncoder] = None
+        self.standard_scaler_dict: Mapping[str, StandardScaler] = None
+        self.onehot_dict: Mapping[str, OneHotEncoder] = None
         self.columns = None
         self.perturb_ratio = perturb_ratio
         self.rescale_ratio = rescale_ratio
@@ -54,17 +54,17 @@ class OneHotAdapter(recourse_adapter.RecourseAdapter):
 
         Returns:
             Itself. Fitting is done mutably."""
-        self.sc_dict = {}
-        self.ohe_dict = {}
+        self.standard_scaler_dict = {}
+        self.onehot_dict = {}
         self.columns = dataset.columns
         for feature in self.continuous_features:
-            sc = StandardScaler()
-            sc.fit(dataset[[feature]])
-            self.sc_dict[feature] = sc
+            standard_scaler = StandardScaler()
+            standard_scaler.fit(dataset[[feature]])
+            self.standard_scaler_dict[feature] = standard_scaler
         for feature in self.categorical_features:
-            ohe = OneHotEncoder()
-            ohe.fit(dataset[[feature]])
-            self.ohe_dict[feature] = ohe
+            onehot_encoder = OneHotEncoder()
+            onehot_encoder.fit(dataset[[feature]])
+            self.onehot_dict[feature] = onehot_encoder
         return self
 
     def transform(
@@ -81,12 +81,18 @@ class OneHotAdapter(recourse_adapter.RecourseAdapter):
         df = dataset.copy()
         for feature in self.continuous_features:
             if feature in df.columns:
-                df[feature] = self.sc_dict[feature].transform(df[[feature]])
+                df[feature] = self.standard_scaler_dict[feature].transform(
+                    df[[feature]]
+                )
         for feature in self.categorical_features:
             if feature in df.columns:
-                ohe = self.ohe_dict[feature]
-                feature_columns = ohe.get_feature_names_out([feature])
-                df[feature_columns] = ohe.transform(df[[feature]]).toarray()
+                onehot_encoder = self.onehot_dict[feature]
+                feature_columns = onehot_encoder.get_feature_names_out(
+                    [feature]
+                )
+                df[feature_columns] = onehot_encoder.transform(
+                    df[[feature]]
+                ).toarray()
                 df = df.drop(feature, axis=1)
         return df
 
@@ -104,14 +110,16 @@ class OneHotAdapter(recourse_adapter.RecourseAdapter):
         df = dataset.copy()
         for feature in self.continuous_features:
             if feature in df.columns:
-                df[feature] = self.sc_dict[feature].inverse_transform(
-                    df[[feature]]
-                )
+                df[feature] = self.standard_scaler_dict[
+                    feature
+                ].inverse_transform(df[[feature]])
         for feature in self.categorical_features:
-            ohe = self.ohe_dict[feature]
-            feature_columns = ohe.get_feature_names_out([feature])
+            onehot_encoder = self.onehot_dict[feature]
+            feature_columns = onehot_encoder.get_feature_names_out([feature])
             if df.columns.intersection(feature_columns).any():
-                df[feature] = ohe.inverse_transform(df[feature_columns])
+                df[feature] = onehot_encoder.inverse_transform(
+                    df[feature_columns]
+                )
                 df = df.drop(feature_columns, axis=1)
         return df
 
@@ -160,8 +168,8 @@ class OneHotAdapter(recourse_adapter.RecourseAdapter):
         if self.rescale_ratio:
             instructions = utils.rescale_dir(instructions, self.rescale_ratio)
         poi = self.transform_series(poi)
-        cfe = poi + instructions
-        return self.inverse_transform_series(cfe)
+        counterfactual = poi + instructions
+        return self.inverse_transform_series(counterfactual)
 
     def column_names(self, drop_label=True) -> Sequence[str]:
         """Returns the column names of the human-readable data.
@@ -197,7 +205,7 @@ class OneHotAdapter(recourse_adapter.RecourseAdapter):
         for feature in features:
             if feature in self.categorical_features:
                 features_out += list(
-                    self.ohe_dict[feature].get_feature_names_out([feature])
+                    self.onehot_dict[feature].get_feature_names_out([feature])
                 )
             else:
                 features_out.append(feature)

--- a/data/adapters/categorical_adapter.py
+++ b/data/adapters/categorical_adapter.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 from data import recourse_adapter
 from typing import Sequence, Optional, Mapping
 from core import utils
-from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn import preprocessing
 import pandas as pd
+
+
+# TODO(@jakeval): Reduce code duplication between this file and
+# continuous_adpater.py
 
 
 class OneHotAdapter(recourse_adapter.RecourseAdapter):
@@ -19,7 +23,7 @@ class OneHotAdapter(recourse_adapter.RecourseAdapter):
         continuous_features: Sequence[str],
         perturb_ratio: Optional[float] = None,
         rescale_ratio: Optional[float] = None,
-        label="Y",
+        label: str = "Y",
     ):
         """Creates a new OneHotAdapter.
 
@@ -36,8 +40,10 @@ class OneHotAdapter(recourse_adapter.RecourseAdapter):
         self.continuous_features = continuous_features
         self.label = label
 
-        self.standard_scaler_dict: Mapping[str, StandardScaler] = None
-        self.onehot_dict: Mapping[str, OneHotEncoder] = None
+        self.standard_scaler_dict: Mapping[
+            str, preprocessing.StandardScaler
+        ] = None
+        self.onehot_dict: Mapping[str, preprocessing.OneHotEncoder] = None
         self.columns = None
         self.perturb_ratio = perturb_ratio
         self.rescale_ratio = rescale_ratio
@@ -58,11 +64,11 @@ class OneHotAdapter(recourse_adapter.RecourseAdapter):
         self.onehot_dict = {}
         self.columns = dataset.columns
         for feature in self.continuous_features:
-            standard_scaler = StandardScaler()
+            standard_scaler = preprocessing.StandardScaler()
             standard_scaler.fit(dataset[[feature]])
             self.standard_scaler_dict[feature] = standard_scaler
         for feature in self.categorical_features:
-            onehot_encoder = OneHotEncoder()
+            onehot_encoder = preprocessing.OneHotEncoder()
             onehot_encoder.fit(dataset[[feature]])
             self.onehot_dict[feature] = onehot_encoder
         return self

--- a/data/adapters/categorical_adapter.py
+++ b/data/adapters/categorical_adapter.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+from data import recourse_adapter
+from typing import Sequence, Optional, Mapping
+from core import utils
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+import pandas as pd
+
+
+class OneHotAdapter(recourse_adapter.RecourseAdapter):
+    """A recourse adapter which one-hot encodes categorical variables and
+    standardizes continuous data to have mean 0 and standard deviation 1.
+
+    The adapter also optionally simulates rescaling the recourse or adding
+    random noise while interpreting recourse instructions."""
+
+    def __init__(
+        self,
+        categorical_features: Sequence[str],
+        continuous_features: Sequence[str],
+        perturb_ratio: Optional[float] = None,
+        rescale_ratio: Optional[float] = None,
+        label="Y",
+    ):
+        """Creates a new OneHotAdapter.
+
+        Args:
+            categorical_features: The names of the categorical features.
+            continuous_features: The names of the continuous features.
+            perturb_ratio: The magnitude of random noise relative to the
+                recourse directions to add while interpreting recourse
+                instructions.
+            rescale_ratio: The amount to rescale the recourse directions by
+                while interpreting recourse instructions.
+            label: The name of the class label feature."""
+        self.categorical_features = categorical_features
+        self.continuous_features = continuous_features
+        self.label = label
+
+        self.sc_dict: Mapping[str, StandardScaler] = None
+        self.ohe_dict: Mapping[str, OneHotEncoder] = None
+        self.columns = None
+        self.perturb_ratio = perturb_ratio
+        self.rescale_ratio = rescale_ratio
+
+    def get_label(self) -> str:
+        """Gets the dataset's label column name."""
+        return self.label
+
+    def fit(self, dataset: pd.DataFrame) -> OneHotAdapter:
+        """Fits the adapter to a dataset.
+
+        Args:
+            dataset: The data to fit.
+
+        Returns:
+            Itself. Fitting is done mutably."""
+        self.sc_dict = {}
+        self.ohe_dict = {}
+        self.columns = dataset.columns
+        for feature in self.continuous_features:
+            sc = StandardScaler()
+            sc.fit(dataset[[feature]])
+            self.sc_dict[feature] = sc
+        for feature in self.categorical_features:
+            ohe = OneHotEncoder()
+            ohe.fit(dataset[[feature]])
+            self.ohe_dict[feature] = ohe
+        return self
+
+    def transform(
+        self, dataset: pd.DataFrame
+    ) -> recourse_adapter.EmbeddedDataFrame:
+        """Transforms data from human-readable format to an embedded continuous
+        space by standardizing the data and one-hot encoding categorical vars.
+
+        Args:
+            dataset: The data to transform.
+
+        Returns:
+            Transformed data."""
+        df = dataset.copy()
+        for feature in self.continuous_features:
+            if feature in df.columns:
+                df[feature] = self.sc_dict[feature].transform(df[[feature]])
+        for feature in self.categorical_features:
+            if feature in df.columns:
+                ohe = self.ohe_dict[feature]
+                feature_columns = ohe.get_feature_names_out([feature])
+                df[feature_columns] = ohe.transform(df[[feature]]).toarray()
+                df = df.drop(feature, axis=1)
+        return df
+
+    def inverse_transform(
+        self, dataset: recourse_adapter.EmbeddedDataFrame
+    ) -> pd.DataFrame:
+        """Transforms data from an embedded continuous space to its original
+        human-readable format.
+
+        Args:
+            dataset: The data to inverse transform.
+
+        Returns:
+            Inverse transformed data."""
+        df = dataset.copy()
+        for feature in self.continuous_features:
+            if feature in df.columns:
+                df[feature] = self.sc_dict[feature].inverse_transform(
+                    df[[feature]]
+                )
+        for feature in self.categorical_features:
+            ohe = self.ohe_dict[feature]
+            feature_columns = ohe.get_feature_names_out([feature])
+            if df.columns.intersection(feature_columns).any():
+                df[feature] = ohe.inverse_transform(df[feature_columns])
+                df = df.drop(feature_columns, axis=1)
+        return df
+
+    def directions_to_instructions(
+        self, directions: recourse_adapter.EmbeddedSeries
+    ) -> recourse_adapter.EmbeddedSeries:
+        """Converts a direction in embedded space to a human-readable
+        instructions format.
+
+        For this class, it is a no-op.
+
+        Args:
+            directions: The continuous recourse directions to convert.
+
+        Returns:
+            Human-readable instructions describing the recourse directions."""
+        return directions
+
+    def interpret_instructions(
+        self, poi: pd.Series, instructions: recourse_adapter.EmbeddedSeries
+    ) -> pd.Series:
+        """Returns a new human-readable data point from an original Point of
+        Interest (POI) and set of recourse instructions.
+
+        Converts the POI to the embedded space and translates it using the
+        embedded space instructions. Then reconverts the POI to its original
+        data space.
+
+        If self.perturb_ratio is not None, adds random noise while translating
+        the POI.
+
+        If self.rescale_ratio is not None, rescales the magnitude of the
+        translation.
+
+        Args:
+            poi: The point of interest (POI) to translate.
+            instructions: The recourse instructions to interpret.
+
+        Returns:
+            A new POI translated from the original by the recourse
+            instructions."""
+        if self.perturb_ratio:
+            instructions = utils.randomly_perturb_dir(
+                instructions, self.perturb_ratio
+            )
+        if self.rescale_ratio:
+            instructions = utils.rescale_dir(instructions, self.rescale_ratio)
+        poi = self.transform_series(poi)
+        cfe = poi + instructions
+        return self.inverse_transform_series(cfe)
+
+    def column_names(self, drop_label=True) -> Sequence[str]:
+        """Returns the column names of the human-readable data.
+
+        Args:
+            drop_label: Whether the label column should be excluded in the
+                output.
+
+        Returns:
+            A list of the column names."""
+        if drop_label:
+            return self.columns.difference([self.label])
+        else:
+            return self.columns
+
+    def embedded_column_names(self, drop_label=True) -> Sequence[str]:
+        """Returns the column names of the data in embedded continuous space.
+
+        Args:
+            drop_label: Whether the label column should be excluded in the
+                output.
+
+        Returns:
+            A list of the column names."""
+        columns = self._get_feature_names_out(self.columns)
+        if drop_label:
+            return [column for column in columns if column != self.label]
+        else:
+            return columns
+
+    def _get_feature_names_out(self, features: Sequence[str]) -> Sequence[str]:
+        features_out = []
+        for feature in features:
+            if feature in self.categorical_features:
+                features_out += list(
+                    self.ohe_dict[feature].get_feature_names_out([feature])
+                )
+            else:
+                features_out.append(feature)
+        return features_out

--- a/data/adapters/continuous_adapter.py
+++ b/data/adapters/continuous_adapter.py
@@ -30,7 +30,7 @@ class StandardizingAdapter(recourse_adapter.RecourseAdapter):
             label: The name of the class label feature."""
         self.label = label
 
-        self.sc_dict: Mapping[str, StandardScaler] = None
+        self.standard_scaler_dict: Mapping[str, StandardScaler] = None
         self.columns = None
         self.continuous_features = None
         self.perturb_ratio = perturb_ratio
@@ -50,11 +50,11 @@ class StandardizingAdapter(recourse_adapter.RecourseAdapter):
             Itself. Fitting is done mutably."""
         self.columns = dataset.columns
         self.continuous_features = dataset.columns.difference([self.label])
-        self.sc_dict = {}
+        self.standard_scaler_dict = {}
         for feature in self.continuous_features:
-            sc = StandardScaler()
-            sc.fit(dataset[[feature]])
-            self.sc_dict[feature] = sc
+            standard_scaler = StandardScaler()
+            standard_scaler.fit(dataset[[feature]])
+            self.standard_scaler_dict[feature] = standard_scaler
         return self
 
     def transform(
@@ -72,7 +72,9 @@ class StandardizingAdapter(recourse_adapter.RecourseAdapter):
         df = dataset.copy()
         for feature in self.continuous_features:
             if feature in df.columns:
-                df[feature] = self.sc_dict[feature].transform(df[[feature]])
+                df[feature] = self.standard_scaler_dict[feature].transform(
+                    df[[feature]]
+                )
         return df
 
     def inverse_transform(
@@ -90,9 +92,9 @@ class StandardizingAdapter(recourse_adapter.RecourseAdapter):
         df = dataset.copy()
         for feature in self.continuous_features:
             if feature in df.columns:
-                df[feature] = self.sc_dict[feature].inverse_transform(
-                    df[[feature]]
-                )
+                df[feature] = self.standard_scaler_dict[
+                    feature
+                ].inverse_transform(df[[feature]])
         return df
 
     def directions_to_instructions(
@@ -140,8 +142,8 @@ class StandardizingAdapter(recourse_adapter.RecourseAdapter):
         if self.rescale_ratio:
             instructions = utils.rescale_dir(instructions, self.rescale_ratio)
         poi = self.transform_series(poi)
-        cfe = poi + instructions
-        return self.inverse_transform_series(cfe)
+        counterfactual = poi + instructions
+        return self.inverse_transform_series(counterfactual)
 
     def column_names(self, drop_label=True) -> Sequence[str]:
         """Returns the column names of the human-readable data.

--- a/data/adapters/continuous_adapter.py
+++ b/data/adapters/continuous_adapter.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 from data import recourse_adapter
 from typing import Sequence, Optional, Mapping
 from core import utils
-from sklearn.preprocessing import StandardScaler
+from sklearn import preprocessing
 import pandas as pd
+
+
+# TODO(@jakeval): Reduce code duplication between this file and
+# categorical_adpater.py
 
 
 class StandardizingAdapter(recourse_adapter.RecourseAdapter):
@@ -17,7 +21,7 @@ class StandardizingAdapter(recourse_adapter.RecourseAdapter):
         self,
         perturb_ratio: Optional[float] = None,
         rescale_ratio: Optional[float] = None,
-        label="Y",
+        label: str = "Y",
     ):
         """Creates a new StandardizingAdapter.
 
@@ -30,7 +34,9 @@ class StandardizingAdapter(recourse_adapter.RecourseAdapter):
             label: The name of the class label feature."""
         self.label = label
 
-        self.standard_scaler_dict: Mapping[str, StandardScaler] = None
+        self.standard_scaler_dict: Mapping[
+            str, preprocessing.StandardScaler
+        ] = None
         self.columns = None
         self.continuous_features = None
         self.perturb_ratio = perturb_ratio
@@ -52,7 +58,7 @@ class StandardizingAdapter(recourse_adapter.RecourseAdapter):
         self.continuous_features = dataset.columns.difference([self.label])
         self.standard_scaler_dict = {}
         for feature in self.continuous_features:
-            standard_scaler = StandardScaler()
+            standard_scaler = preprocessing.StandardScaler()
             standard_scaler.fit(dataset[[feature]])
             self.standard_scaler_dict[feature] = standard_scaler
         return self

--- a/data/adapters/continuous_adapter.py
+++ b/data/adapters/continuous_adapter.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+from data import recourse_adapter
+from typing import Sequence, Optional, Mapping
+from core import utils
+from sklearn.preprocessing import StandardScaler
+import pandas as pd
+
+
+class StandardizingAdapter(recourse_adapter.RecourseAdapter):
+    """A recourse adapter which standardizes continuous data to have mean 0 and
+    standard deviation 1.
+
+    The adapter also optionally simulates rescaling the recourse or adding
+    random noise while interpreting recourse instructions."""
+
+    def __init__(
+        self,
+        perturb_ratio: Optional[float] = None,
+        rescale_ratio: Optional[float] = None,
+        label="Y",
+    ):
+        """Creates a new StandardizingAdapter.
+
+        Args:
+            perturb_ratio: The magnitude of random noise relative to the
+                recourse directions to add while interpreting recourse
+                instructions.
+            rescale_ratio: The amount to rescale the recourse directions by
+                while interpreting recourse instructions.
+            label: The name of the class label feature."""
+        self.label = label
+
+        self.sc_dict: Mapping[str, StandardScaler] = None
+        self.columns = None
+        self.continuous_features = None
+        self.perturb_ratio = perturb_ratio
+        self.rescale_ratio = rescale_ratio
+
+    def get_label(self) -> str:
+        """Gets the dataset's label column name."""
+        return self.label
+
+    def fit(self, dataset: pd.DataFrame) -> StandardizingAdapter:
+        """Fits the adapter to a dataset.
+
+        Args:
+            dataset: The data to fit.
+
+        Returns:
+            Itself. Fitting is done mutably."""
+        self.columns = dataset.columns
+        self.continuous_features = dataset.columns.difference([self.label])
+        self.sc_dict = {}
+        for feature in self.continuous_features:
+            sc = StandardScaler()
+            sc.fit(dataset[[feature]])
+            self.sc_dict[feature] = sc
+        return self
+
+    def transform(
+        self, dataset: pd.DataFrame
+    ) -> recourse_adapter.EmbeddedDataFrame:
+        """Transforms data from human-readable format to an embedded continuous
+        space by standardizing the data to have 0 mean and standard deviation
+        1.
+
+        Args:
+            dataset: The data to transform.
+
+        Returns:
+            Transformed data."""
+        df = dataset.copy()
+        for feature in self.continuous_features:
+            if feature in df.columns:
+                df[feature] = self.sc_dict[feature].transform(df[[feature]])
+        return df
+
+    def inverse_transform(
+        self, dataset: recourse_adapter.EmbeddedDataFrame
+    ) -> pd.DataFrame:
+        """Transforms data from an embedded continuous space to its original
+        human-readable format by restoring the original dataset mean and
+        standard deviation.
+
+        Args:
+            dataset: The data to inverse transform.
+
+        Returns:
+            Inverse transformed data."""
+        df = dataset.copy()
+        for feature in self.continuous_features:
+            if feature in df.columns:
+                df[feature] = self.sc_dict[feature].inverse_transform(
+                    df[[feature]]
+                )
+        return df
+
+    def directions_to_instructions(
+        self, directions: recourse_adapter.EmbeddedSeries
+    ) -> recourse_adapter.EmbeddedSeries:
+        """Converts a direction in embedded space to a human-readable
+        instructions format.
+
+        For this class, it is a no-op.
+
+        Args:
+            directions: The continuous recourse directions to convert.
+
+        Returns:
+            Human-readable instructions describing the recourse directions."""
+        return directions
+
+    def interpret_instructions(
+        self, poi: pd.Series, instructions: recourse_adapter.EmbeddedSeries
+    ) -> pd.Series:
+        """Returns a new human-readable data point from an original Point of
+        Interest (POI) and set of recourse instructions.
+
+        Converts the POI to the embedded space and translates it using the
+        embedded space instructions. Then reconverts the POI to its original
+        data space.
+
+        If self.perturb_ratio is not None, adds random noise while translating
+        the POI.
+
+        If self.rescale_ratio is not None, rescales the magnitude of the
+        translation.
+
+        Args:
+            poi: The point of interest (POI) to translate.
+            instructions: The recourse instructions to interpret.
+
+        Returns:
+            A new POI translated from the original by the recourse
+            instructions."""
+        if self.perturb_ratio:
+            instructions = utils.randomly_perturb_dir(
+                instructions, self.perturb_ratio
+            )
+        if self.rescale_ratio:
+            instructions = utils.rescale_dir(instructions, self.rescale_ratio)
+        poi = self.transform_series(poi)
+        cfe = poi + instructions
+        return self.inverse_transform_series(cfe)
+
+    def column_names(self, drop_label=True) -> Sequence[str]:
+        """Returns the column names of the human-readable data.
+
+        Args:
+            drop_label: Whether the label column should be excluded in the
+                output.
+
+        Returns:
+            A list of the column names."""
+        if drop_label:
+            return self.columns.difference([self.label])
+        else:
+            return self.columns
+
+    def embedded_column_names(self, drop_label=True) -> Sequence[str]:
+        """Returns the column names of the data in embedded continuous space.
+
+        Args:
+            drop_label: Whether the label column should be excluded in the
+                output.
+
+        Returns:
+            A list of the column names."""
+        if drop_label:
+            return self.columns.difference([self.label])
+        else:
+            return self.columns

--- a/data/recourse_adapter.py
+++ b/data/recourse_adapter.py
@@ -1,13 +1,15 @@
-from __future__ import annotations
-from typing import Any, Sequence, Mapping, Optional
+from typing import Any, Sequence
 import pandas as pd
 import abc
-from core import utils
-from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
 
 class EmbeddedDataFrame(pd.DataFrame):
-    """A wrapper around DataFrame for purely numeric data."""
+    """A wrapper around DataFrame for continuous data.
+
+    Recourse directions are generated in embedded continuous space. DataFrames
+    with categorical directions must be converted to EmbeddedDataFrames before
+    directional recourse can be generated."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._check_types_are_numeric()
@@ -15,194 +17,133 @@ class EmbeddedDataFrame(pd.DataFrame):
     def _check_types_are_numeric(self):
         for col, dtype in zip(self.columns, self.dtypes):
             if not pd.api.types.is_numeric_dtype(dtype):
-                raise ValueError(f"Column {col} has type {dtype} which is not numeric.")
+                raise ValueError(
+                    f"Column {col} has type {dtype} which is not numeric."
+                )
         return True
 
 
 class EmbeddedSeries(pd.Series):
-    """A wrapper around Series for purely numeric data."""
+    """A wrapper around Series for continuous data.
+
+    Recourse directions are generated in embedded continuous space. Series
+    with categorical directions must be converted to EmbeddedSeries before
+    directional recourse can be generated."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._check_types_are_numeric()
 
     def _check_types_are_numeric(self):
         if not pd.api.types.is_numeric_dtype(self.dtype):
-            raise ValueError(f"Series has type {self.dtype} which is not numeric.")
+            raise ValueError(
+                f"Series has type {self.dtype} which is not numeric."
+            )
         return True
 
 
 class RecourseAdapter(abc.ABC):
-    """An abstract base class for dataset adapters.
-    
-    The adapter translates between human-readable and embedded space.
-    """
+    """An abstract base class for recourse adapters.
+
+    The adapter translates between the original (possibly categorical) data
+    space and continuous embedded space where recourse directions are
+    generated. It also iterates recourse by converting directions in embedded
+    space to human-readable instructions and interpreting recourse instructions
+    as a hypothetical user would."""
+
     @abc.abstractmethod
     def get_label(self) -> str:
         """Gets the dataset's label column name."""
+        pass
 
     @abc.abstractmethod
     def transform(self, dataset: pd.DataFrame) -> EmbeddedDataFrame:
-        """Transforms data from human-readable format to an embedded numeric space."""
+        """Transforms data from human-readable format to an embedded continuous
+        space.
+
+        Args:
+            dataset: The data to transform.
+
+        Returns:
+            Transformed data."""
 
     @abc.abstractmethod
     def inverse_transform(self, dataset: EmbeddedDataFrame) -> pd.DataFrame:
-        """Transforms data from an embedded numeric space to its original human-readable format."""
+        """Transforms data from an embedded continuous space to its original
+        human-readable format.
+
+        Args:
+            dataset: The data to inverse transform.
+
+        Returns:
+            Inverse transformed data."""
 
     @abc.abstractmethod
     def directions_to_instructions(self, directions: EmbeddedSeries) -> Any:
-        """Converts a direction in embedded space to some human-readable instructions format."""
+        """Converts a direction in embedded space to a human-readable
+        instructions format.
+
+        Args:
+            directions: The continuous recourse directions to convert.
+
+        Returns:
+            Human-readable instructions describing the recourse directions."""
 
     @abc.abstractmethod
-    def interpret_instructions(self, poi: pd.Series, instructions: Any) -> pd.Series:
-        """Returns a new human-readable data point from an original POI and set of instructions.
-        
-        Interprets the instructions by translating the original human-readable POI."""
+    def interpret_instructions(
+        self, poi: pd.Series, instructions: Any
+    ) -> pd.Series:
+        """Returns a new human-readable data point from an original POI and set
+        of recourse instructions.
+        Interprets the instructions by translating the original human-readable
+        POI.
+
+        Args:
+            poi: The point of interest (POI) to translate.
+            instructions: The recourse instructions to interpret.
+
+        Returns:
+            A new POI translated from the original by the recourse
+            instructions."""
 
     @abc.abstractmethod
     def column_names(self, drop_label=True) -> Sequence[str]:
-        """Returns the column names of the human-readable data."""
+        """Returns the column names of the human-readable data.
+
+        Args:
+            drop_label: Whether the label column should be excluded in the
+                output.
+
+        Returns:
+            A list of the column names."""
 
     @abc.abstractmethod
     def embedded_column_names(self, drop_label=True) -> Sequence[str]:
-        """Returns the column names of the data in embedded numeric space."""
+        """Returns the column names of the data in embedded continuous space.
+
+        Args:
+            drop_label: Whether the label column should be excluded in the
+                output.
+        Returns:
+            A list of the column names."""
 
     def transform_series(self, poi: pd.Series) -> EmbeddedSeries:
-        """Transforms data from human-readable format to an embedded numeric space."""
+        """Transforms data from human-readable format to an embedded continuous
+        space.
+
+        Args:
+            dataset: The data to transform.
+
+        Returns:
+            Transformed data."""
         return self.transform(poi.to_frame().T).iloc[0]
 
     def inverse_transform_series(self, poi: EmbeddedSeries) -> pd.Series:
-        """Transforms data from an embedded numeric space to its original human-readable format."""
+        """Transforms data from an embedded continuous space to its original
+        human-readable format.
+        Args:
+            dataset: The data to inverse transform.
+
+        Returns:
+            Inverse transformed data."""
         return self.inverse_transform(poi.to_frame().T).iloc[0]
-
-
-class NaiveAdapter(RecourseAdapter):
-    """A Naive adapter which standardizes numeric columns and one hot encodes categorical columns."""
-    def __init__(self,
-                 categorical_features: Sequence[str],
-                 continuous_features: Sequence[str],
-                 perturb_ratio: Optional[float] = None,
-                 rescale_ratio: Optional[float] = None,
-                 label='Y'):
-        self.categorical_features = categorical_features
-        self.continuous_features = continuous_features
-        self.label = label
-
-        self.sc_dict: Mapping[str, StandardScaler] = None
-        self.ohe_dict: Mapping[str, OneHotEncoder] = None
-        self.columns = None
-        self.perturb_ratio = perturb_ratio
-        self.rescale_ratio = rescale_ratio
-
-    def get_label(self) -> str:
-        return self.label
-
-    def fit(self, dataset: pd.DataFrame) -> NaiveAdapter:
-        self.sc_dict = {}
-        self.ohe_dict = {}
-        self.columns = dataset.columns
-        for feature in self.continuous_features:
-            sc = StandardScaler()
-            sc.fit(dataset[[feature]])
-            self.sc_dict[feature] = sc
-        for feature in self.categorical_features:
-            ohe = OneHotEncoder()
-            ohe.fit(dataset[[feature]])
-            self.ohe_dict[feature] = ohe
-        return self
-
-    def transform(self, dataset: pd.DataFrame) -> EmbeddedDataFrame:
-        df = dataset.copy()
-        for feature in self.continuous_features:
-            if feature in df.columns:
-                df[feature] = self.sc_dict[feature].transform(df[[feature]])
-        for feature in self.categorical_features:
-            if feature in df.columns:
-                ohe = self.ohe_dict[feature]
-                feature_columns = ohe.get_feature_names_out([feature])
-                df[feature_columns] = ohe.transform(df[[feature]]).toarray()
-                df = df.drop(feature, axis=1)
-        return df
-
-    def inverse_transform(self, dataset: EmbeddedDataFrame) -> pd.DataFrame:
-        df = dataset.copy()
-        for feature in self.continuous_features:
-            if feature in df.columns:
-                df[feature] = self.sc_dict[feature].inverse_transform(df[[feature]])
-        for feature in self.categorical_features:
-            ohe = self.ohe_dict[feature]
-            feature_columns = ohe.get_feature_names_out([feature])
-            if df.columns.intersection(feature_columns).any():
-                df[feature] = ohe.inverse_transform(df[feature_columns])
-                df = df.drop(feature_columns, axis=1)
-        return df
-
-    def directions_to_instructions(self, directions: EmbeddedSeries) -> EmbeddedSeries:
-        return directions
-
-    def interpret_instructions(self, poi: pd.Series, instructions: EmbeddedSeries) -> pd.Series:
-        if self.perturb_ratio:
-            instructions = utils.randomly_perturb_dir(instructions, self.perturb_ratio)
-        if self.rescale_ratio:
-            instructions = utils.rescale_dir(instructions, self.rescale_ratio)
-        poi = self.transform_series(poi)
-        cfe = poi + instructions
-        return self.inverse_transform_series(cfe)
-
-    def column_names(self, drop_label=True) -> Sequence[str]:
-        if drop_label:
-            return self.columns.difference([self.label])
-        else:
-            return self.columns
-
-    def embedded_column_names(self, drop_label=True) -> Sequence[str]:
-        columns = self._get_feature_names_out(self.columns)
-        if drop_label:
-            return [column for column in columns if column != self.label]
-        else:
-            return columns
-
-    def _get_feature_names_out(self, features: Sequence[str]) -> Sequence[str]:
-        features_out = []
-        for feature in features:
-            if feature in self.categorical_features:
-                features_out += list(self.ohe_dict[feature].get_feature_names_out([feature]))
-            else:
-                features_out.append(feature)
-        return features_out
-
-
-class PassthroughAdapter(RecourseAdapter):
-    def __init__(self, label='Y'):
-        self.columns = None
-        self.label = label
-
-    def get_label(self) -> str:
-        return self.label
-
-    def fit(self, dataset: pd.DataFrame) -> PassthroughAdapter:
-        self.columns = dataset.columns
-        return self
-
-    def transform(self, dataset: pd.DataFrame) -> EmbeddedDataFrame:
-        return dataset
-
-    def inverse_transform(self, dataset: EmbeddedDataFrame) -> pd.DataFrame:
-        return dataset
-
-    def directions_to_instructions(self, directions: EmbeddedSeries) -> EmbeddedSeries:
-        return directions
-
-    def interpret_instructions(self, poi: pd.Series, instructions: EmbeddedSeries) -> pd.Series:
-        return poi + instructions
-
-    def column_names(self, drop_label=True) -> Sequence[str]:
-        if drop_label:
-            return self.columns.difference([self.label])
-        else:
-            return self.columns
-
-    def embedded_column_names(self, drop_label=True) -> Sequence[str]:
-        if drop_label:
-            return self.columns.difference([self.label])
-        else:
-            return self.columns

--- a/data/recourse_adapter.py
+++ b/data/recourse_adapter.py
@@ -127,23 +127,25 @@ class RecourseAdapter(abc.ABC):
         Returns:
             A list of the column names."""
 
-    def transform_series(self, poi: pd.Series) -> EmbeddedSeries:
+    def transform_series(self, data_series: pd.Series) -> EmbeddedSeries:
         """Transforms data from human-readable format to an embedded continuous
         space.
 
         Args:
-            dataset: The data to transform.
+            data_series: The data to transform.
 
         Returns:
             Transformed data."""
-        return self.transform(poi.to_frame().T).iloc[0]
+        return self.transform(data_series.to_frame().T).iloc[0]
 
-    def inverse_transform_series(self, poi: EmbeddedSeries) -> pd.Series:
+    def inverse_transform_series(
+        self, data_series: EmbeddedSeries
+    ) -> pd.Series:
         """Transforms data from an embedded continuous space to its original
         human-readable format.
         Args:
-            dataset: The data to inverse transform.
+            data_series: The data to inverse transform.
 
         Returns:
             Inverse transformed data."""
-        return self.inverse_transform(poi.to_frame().T).iloc[0]
+        return self.inverse_transform(data_series.to_frame().T).iloc[0]

--- a/data/recourse_adapter.py
+++ b/data/recourse_adapter.py
@@ -3,6 +3,11 @@ import pandas as pd
 import abc
 
 
+# TODO(@jakeval): Reconsider this class's responsibilities -- it does too much.
+# It should only translate between embedded and native data formats. Generating
+# instructions and taking actions should be done separately.
+
+
 class EmbeddedDataFrame(pd.DataFrame):
     """A wrapper around DataFrame for continuous data.
 

--- a/recourse_methods/dice_method.py
+++ b/recourse_methods/dice_method.py
@@ -1,16 +1,18 @@
 from typing import Sequence, Optional, Mapping, Any
 from recourse_methods import base_type
 import pandas as pd
-from data import data_preprocessor as dp
+from data import recourse_adapter
 import dice_ml
 from dice_ml import constants
 from sklearn import pipeline
 
 
+# TODO(@jakeval): This will be refactored with the model update.
 class ToNumPy:
     """This is a temporary class used until model handling is refactored.
 
     It is used in an sklearn pipeline to convert pandas DataFrames to NumPy arrays."""
+
     def __init__(self):
         pass
 
@@ -24,19 +26,21 @@ class ToNumPy:
 class DiCE(base_type.RecourseMethod):
     """An abstract base class for recourse methods."""
 
-    def __init__(self,
-                 k_directions: int,
-                 preprocessor: dp.Preprocessor,
-                 dataset: pd.DataFrame,
-                 continuous_features: Sequence[str],
-                 model: Any,
-                 model_backend: constants.BackEndTypes,
-                 label_column: str = 'Y',
-                 dice_kwargs: Optional[Mapping[str, Any]] = None,
-                 dice_cfe_kwargs: Optional[Mapping[str, Any]] = None):
+    def __init__(
+        self,
+        k_directions: int,
+        adapter: recourse_adapter.RecourseAdapter,
+        dataset: pd.DataFrame,
+        continuous_features: Sequence[str],
+        model: Any,
+        model_backend: constants.BackEndTypes,
+        label_column: str = "Y",
+        dice_kwargs: Optional[Mapping[str, Any]] = None,
+        dice_cfe_kwargs: Optional[Mapping[str, Any]] = None,
+    ):
         """Constructs a new DiCE recourse method.
 
-        The Preprocessor translates between the original data format (potentially
+        The RecourseAdapter translates between the original data format (potentially
         with categorical features) and a continuous embedded space. Recourse
         directions are generated in embedded space and interpreted as instructions
         in the original data format.
@@ -47,7 +51,7 @@ class DiCE(base_type.RecourseMethod):
 
         Args:
             k_directions: The number of recourse directions to generate.
-            preprocessor: The dataset preprocessor.
+            adapter: The dataset adapter.
             dataset: The dataset to perform recourse over.
             continuous_features: A list of the dataset's continuous features.
             model: An ML model satisfying one of the DiCE model backends.
@@ -57,27 +61,33 @@ class DiCE(base_type.RecourseMethod):
             dice_recourse_kwargs: Optional arguments to pass to DiCE on counterfactual explanation generation.
         """
         self.k_directions = k_directions
-        self.preprocessor = preprocessor
+        self.adapter = adapter
         self.dice_cfe_kwargs = dice_cfe_kwargs
         self.label_column = label_column
         d = dice_ml.Data(
             dataframe=dataset,
             continuous_features=continuous_features,
-            outcome_name=label_column
+            outcome_name=label_column,
         )
-        clf = pipeline.Pipeline(steps=[('preprocessor', preprocessor),
-                                       ('tonumpy', ToNumPy()),
-                                       ('classifier', model)])
+        clf = pipeline.Pipeline(
+            steps=[
+                ("adapter", adapter),
+                ("tonumpy", ToNumPy()),
+                ("classifier", model),
+            ]
+        )
         m = dice_ml.Model(model=clf, backend=model_backend)
         dice_args = {
-            'data_interface': d,
-            'model_interface': m,
+            "data_interface": d,
+            "model_interface": m,
         }
         if dice_kwargs:
             dice_args.update(dice_kwargs)
         self.dice = dice_ml.Dice(**dice_args)
 
-    def get_all_recourse_directions(self, poi: dp.EmbeddedSeries) -> dp.EmbeddedDataFrame:
+    def get_all_recourse_directions(
+        self, poi: recourse_adapter.EmbeddedSeries
+    ) -> recourse_adapter.EmbeddedDataFrame:
         """Generates different recourse directions for the poi for each of the k_directions.
 
         Args:
@@ -85,7 +95,7 @@ class DiCE(base_type.RecourseMethod):
 
         Returns:
             A DataFrame containing recourse directions for the POI."""
-        poi = self.preprocessor.inverse_transform_series(poi)
+        poi = self.adapter.inverse_transform_series(poi)
         cfes = self._generate_counterfactuals(poi, self.k_directions)
         directions = self._counterfactuals_to_directions(poi, cfes)
         return directions
@@ -106,11 +116,15 @@ class DiCE(base_type.RecourseMethod):
         directions = self._counterfactuals_to_directions(poi, cfes)
         instructions = []
         for i in range(len(cfes)):
-            instruction = self.preprocessor.directions_to_instructions(directions.iloc[i])
+            instruction = self.adapter.directions_to_instructions(
+                directions.iloc[i]
+            )
             instructions.append(instruction)
         return instructions
 
-    def get_kth_recourse_instructions(self, poi: pd.Series, dir_index: int) -> Any:
+    def get_kth_recourse_instructions(
+        self, poi: pd.Series, dir_index: int
+    ) -> Any:
         """Generates a single set of recourse instructions for the kth direction.
 
         Args:
@@ -120,9 +134,11 @@ class DiCE(base_type.RecourseMethod):
             Instructions for the POI to achieve the recourse."""
         cfes = self._generate_counterfactuals(poi, 1)
         directions = self._counterfactuals_to_directions(poi, cfes)
-        return self.preprocessor.directions_to_instructions(directions.iloc[0])
+        return self.adapter.directions_to_instructions(directions.iloc[0])
 
-    def _generate_counterfactuals(self, poi: pd.Series, num_cfes: int) -> pd.DataFrame:
+    def _generate_counterfactuals(
+        self, poi: pd.Series, num_cfes: int
+    ) -> pd.DataFrame:
         """Generates DiCE counterfactual examples for the requested POI.
 
         Args:
@@ -131,16 +147,22 @@ class DiCE(base_type.RecourseMethod):
         Returns:
             A DataFrame of counterfactual examples."""
         cfe_args = {
-            'query_instances': poi.to_frame().T,
-            'total_CFs': num_cfes,
-            'desired_class': 'opposite',
-            'verbose': False
+            "query_instances": poi.to_frame().T,
+            "total_CFs": num_cfes,
+            "desired_class": "opposite",
+            "verbose": False,
         }
         if self.dice_cfe_kwargs:
             cfe_args.update(self.dice_cfe_kwargs)
-        return self.dice.generate_counterfactuals(**cfe_args).cf_examples_list[0].final_cfs_df.drop(self.label_column, axis=1)
+        return (
+            self.dice.generate_counterfactuals(**cfe_args)
+            .cf_examples_list[0]
+            .final_cfs_df.drop(self.label_column, axis=1)
+        )
 
-    def _counterfactuals_to_directions(self, poi: pd.Series, cfes: pd.DataFrame) -> dp.EmbeddedDataFrame:
+    def _counterfactuals_to_directions(
+        self, poi: pd.Series, cfes: pd.DataFrame
+    ) -> recourse_adapter.EmbeddedDataFrame:
         """Converts a DataFrame of counterfactual points to a DataFrame of Embedded directions pointing from the POI to the CFEs.
 
         Args:
@@ -149,7 +171,7 @@ class DiCE(base_type.RecourseMethod):
 
         Returns:
             A DataFrame of recourse directions in embedded space."""
-        poi = self.preprocessor.transform_series(poi)
-        cfes = self.preprocessor.transform(cfes)
+        poi = self.adapter.transform_series(poi)
+        cfes = self.adapter.transform(cfes)
         dirs = cfes - poi
         return dirs


### PR DESCRIPTION
recourse_adapter.py retains the base types EmbeddedDataFrame, EmbeddedSeries, and RecourseAdapter. The NaiveAdapter is split into two classes:

* StandardizingAdapter is defined in data/adapters/continuous_adapter.py
* OneHotAdapter is defined in data/adapters/categorical_adapter.py

The PassThrough adapter is no longer used and has been deleted. Docstrings have been updated.

## Feedback requested
Minor style feedback like line length or inconsistent quotation use is not required -- this can be refactored via linting before the full release.

Major style and documentation feedback impacting code clarity is requested. Do the naming conventions make sense? Are the abstractions appropriate?