### PR TITLE
[Testing] Refactored and tested data processing in mrmc_method.py

### DIFF
--- a/core/test_utils.py
+++ b/core/test_utils.py
@@ -8,12 +8,11 @@ class TestUtils(unittest.TestCase):
     @mock.patch("core.utils.np.random.normal", return_value=np.array([1, 0]))
     def test_randomly_perturb_direction(self, mock_normal: mock.Mock):
         new_direction = utils.randomly_perturb_direction(np.array([0, 1]), 1)
-        expected_direction = np.array([np.sqrt(0.5), np.sqrt(0.5)])
-        for new_val, expected_val in zip(new_direction, expected_direction):
-            self.assertAlmostEqual(new_val, expected_val)
-        self.assertAlmostEqual(
-            np.linalg.norm(new_direction), np.linalg.norm(np.array([0, 1]))
+        expected_direction = np.array([0.70711, 0.70711])  # from sqrt(0.5)
+        np.testing.assert_almost_equal(
+            new_direction, expected_direction, decimal=5
         )
+        self.assertAlmostEqual(np.linalg.norm(new_direction), 1.0)
 
     @mock.patch("core.utils.np.random.normal", return_value=np.array([1, 0]))
     def test_randomly_perturb_direction_zero_ratio(
@@ -21,11 +20,8 @@ class TestUtils(unittest.TestCase):
     ):
         new_direction = utils.randomly_perturb_direction(np.array([0, 1]), 0)
         expected_direction = np.array([0, 1])
-        for new_val, expected_val in zip(new_direction, expected_direction):
-            self.assertAlmostEqual(new_val, expected_val)
-        self.assertAlmostEqual(
-            np.linalg.norm(new_direction), np.linalg.norm(np.array([0, 1]))
-        )
+        np.testing.assert_almost_equal(new_direction, expected_direction)
+        self.assertAlmostEqual(np.linalg.norm(new_direction), 1.0)
 
     @mock.patch("core.utils.np.random.normal", return_value=np.array([1, 0]))
     def test_randomly_perturb_direction_zero_direction(
@@ -33,8 +29,7 @@ class TestUtils(unittest.TestCase):
     ):
         new_direction = utils.randomly_perturb_direction(np.array([0, 0]), 0.5)
         expected_direction = np.array([0, 0])
-        for new_val, expected_val in zip(new_direction, expected_direction):
-            self.assertAlmostEqual(new_val, expected_val)
+        np.testing.assert_almost_equal(new_direction, expected_direction)
 
     @mock.patch("core.utils.np.random.normal", return_value=np.array([0, 0]))
     def test_randomly_perturb_direction_zero_noise(
@@ -42,24 +37,22 @@ class TestUtils(unittest.TestCase):
     ):
         new_direction = utils.randomly_perturb_direction(np.array([0, 1]), 0.5)
         expected_direction = np.array([0, 1])
-        for new_val, expected_val in zip(new_direction, expected_direction):
-            self.assertAlmostEqual(new_val, expected_val)
+        np.testing.assert_almost_equal(new_direction, expected_direction)
 
     def test_constant_step_size(self):
         new_direction = utils.constant_step_size(np.array([1, 1]), 0.5)
-        expected_direction = np.array([np.sqrt(1 / 8), np.sqrt(1 / 8)])
-        for new_val, expected_val in zip(new_direction, expected_direction):
-            self.assertAlmostEqual(new_val, expected_val)
+        expected_direction = np.array([0.35355, 0.35355])  # from sqrt(1/8)
+        np.testing.assert_almost_equal(
+            new_direction, expected_direction, decimal=5
+        )
         self.assertAlmostEqual(np.linalg.norm(new_direction), 0.5)
 
     def test_constant_step_size_zero_direction(self):
         new_direction = utils.constant_step_size(np.array([0, 0]), 0.5)
         expected_direction = np.array([0, 0])
-        for new_val, expected_val in zip(new_direction, expected_direction):
-            self.assertAlmostEqual(new_val, expected_val)
+        np.testing.assert_almost_equal(new_direction, expected_direction)
 
     def test_constant_step_size_zero_step_size(self):
         new_direction = utils.constant_step_size(np.array([1, 1]), 0)
         expected_direction = np.array([0, 0])
-        for new_val, expected_val in zip(new_direction, expected_direction):
-            self.assertAlmostEqual(new_val, expected_val)
+        np.testing.assert_almost_equal(new_direction, expected_direction)

--- a/data/adapters/continuous_adapter.py
+++ b/data/adapters/continuous_adapter.py
@@ -69,7 +69,7 @@ class StandardizingAdapter(recourse_adapter.RecourseAdapter):
             self.standard_scaler_dict[feature] = standard_scaler
         return self
 
-    # TODO(@jakeval): Confidence check this
+    # TODO(@jakeval): Unit test this
     def transform(
         self, dataset: pd.DataFrame
     ) -> recourse_adapter.EmbeddedDataFrame:
@@ -91,7 +91,7 @@ class StandardizingAdapter(recourse_adapter.RecourseAdapter):
                 )
         return df
 
-    # TODO(@jakeval): Confidence check this
+    # TODO(@jakeval): Unit test this
     def inverse_transform(
         self, dataset: recourse_adapter.EmbeddedDataFrame
     ) -> pd.DataFrame:

--- a/recourse_methods/mrmc_method.py
+++ b/recourse_methods/mrmc_method.py
@@ -158,10 +158,9 @@ class MRM:
     ) -> recourse_adapter.EmbeddedDataFrame:
         """Processes the dataset for MRM.
 
-        It filters out negative outcome points, drops the class label, and
-        transforms the data to a numeric embedded space. If
-        confidence_threshold is provided, it also filters out points which have
-        insufficient model confidence.
+        Removes datapoints with negative (-1) labels, drops the class label
+        feature column, and transforms the data to a numeric embedded space.
+        Also excludes datapoints with below-threshold model confidence.
 
         Args:
             dataset: The dataset to process.

--- a/recourse_methods/mrmc_method.py
+++ b/recourse_methods/mrmc_method.py
@@ -260,7 +260,6 @@ class MRMC(RecourseMethod):
     each cluster.
     """
 
-    # TODO(@jakeval): Test this -- is each MRM initialized correctly?
     def __init__(
         self,
         k_directions: int,

--- a/recourse_methods/mrmc_method.py
+++ b/recourse_methods/mrmc_method.py
@@ -174,7 +174,9 @@ class MRM:
             A processed dataset.
         """
         positive_mask = dataset[adapter.label_column] == adapter.positive_label
-        if confidence_threshold:  # Only include "sufficiently" positive points
+        # Keep positively-labeled points with sufficiently high model
+        # prediction confidence
+        if confidence_threshold:
             positive_mask = positive_mask & (
                 model.predict_pos_proba(dataset) > confidence_threshold
             )

--- a/recourse_methods/mrmc_method.py
+++ b/recourse_methods/mrmc_method.py
@@ -92,7 +92,24 @@ class AlphaFunction(Protocol):
 
 
 class MRM:
-    """Monotone Recourse Measures (MRM) generates recourse directions."""
+    """Monotone Recourse Measures (MRM) generates recourse directions.
+
+    MRM processes an input dataset for recourse using MRM.process_data(). The
+    data processing step can be skipped by directly assigning the class
+    attribute _processed_data with data ready for recourse.
+
+    Data provided to _processed_data should
+        * Consist only of positively classified examples
+        * Not have the label column
+        * Be transformed into an embedded numerical space by the adapter.
+
+    Attributes:
+        data: The dataset used for recourse.
+        adapter: A RecourseAdapter object to transform the data between
+            human-readable and embedded space.
+        alpha: The alpha function to use during recourse generation.
+        rescale_direction: A function for rescaling the recourse.
+    """
 
     def __init__(
         self,
@@ -105,15 +122,6 @@ class MRM:
         _processed_data: Optional[recourse_adapter.EmbeddedDataFrame] = None,
     ):
         """Creates an MRM instance.
-
-        The dataset is processed for recourse using MRM.process_data(). The
-        data processing step can be skipped by directly assigning the class
-        attribute _processed_data with data ready for recourse.
-
-        Data provided to _processed_data should
-            * Consist only of positively classified examples
-            * Not have the label column
-            * Be transformed into an embedded numerical space by the adapter.
 
         Args:
             dataset: The dataset to provide recourse over.
@@ -258,6 +266,12 @@ class MRMC(RecourseMethod):
 
     MRMC clusters the data and initializes a separate MRM instance for
     each cluster.
+
+    Attributes:
+        k_directions: The number of clusters (and recourse directions) to
+            generate.
+        clusters: The clusters used for generating recourse.
+        mrms: The individual per-cluster MRM instances.
     """
 
     def __init__(

--- a/recourse_methods/mrmc_method.py
+++ b/recourse_methods/mrmc_method.py
@@ -208,7 +208,7 @@ class MRM:
         alpha_val = self.alpha(dist)
         if np.isnan(alpha_val).any():
             raise RuntimeError(
-                f"Alpha function returned null values: {alpha_val}"
+                f"Alpha function returned NaN values: {alpha_val}"
             )
         direction = diff.T @ alpha_val
         return recourse_adapter.EmbeddedSeries(index=poi.index, data=direction)
@@ -338,7 +338,7 @@ class MRMC(RecourseMethod):
     def _cluster_data(
         data: recourse_adapter.EmbeddedDataFrame, k_directions: int
     ) -> Clusters:
-        """Clusters the data using k-means clustering.
+        """Clusters the data using sklearn's KMeans clustering.
 
         Args:
             data: The data to cluster in embedded continuous space.
@@ -365,7 +365,7 @@ class MRMC(RecourseMethod):
     def _validate_cluster_assignments(
         cluster_assignments: pd.DataFrame, k_directions: int
     ) -> bool:
-        """Raises an error if the cluster_assignments is valid.
+        """Raises an error if the cluster_assignments is invalid.
 
         Invalid cluster_assignments have more or fewer clusters than the
         requested k_directions.

--- a/recourse_methods/mrmc_method.py
+++ b/recourse_methods/mrmc_method.py
@@ -106,9 +106,9 @@ class MRM:
     ):
         """Creates an MRM instance.
 
-        The dataset is processed for recourse using MRM.process_data(). This
-        processing step can be skipped by providing recourse data directly via
-        _processed_data. This is typically unnecessary for end users.
+        The dataset is processed for recourse using MRM.process_data(). The
+        data processing step can be skipped by directly assigning the class
+        attribute _processed_data with data ready for recourse.
 
         Data provided to _processed_data should
             * Consist only of positively classified examples

--- a/recourse_methods/mrmc_method.py
+++ b/recourse_methods/mrmc_method.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Protocol, Sequence
+from typing import Any, Protocol, Sequence, Optional
 from dataclasses import dataclass
 import numpy as np
 from core import utils
@@ -92,16 +92,28 @@ class AlphaFunction(Protocol):
 
 
 class MRM:
-    """Monotone Recourse Measures generates recourse directions."""
+    """Monotone Recourse Measures (MRM) generates recourse directions."""
 
     def __init__(
         self,
         dataset: pd.DataFrame,
         adapter: recourse_adapter.RecourseAdapter,
         alpha: AlphaFunction = get_volcano_alpha(),
-        rescale_direction: RecourseRescaler = normalize_rescaler,
+        rescale_direction: Optional[RecourseRescaler] = normalize_rescaler,
+        confidence_threshold: Optional[float] = None,
+        model: Optional[model_interface.Model] = None,
+        _processed_data: Optional[recourse_adapter.EmbeddedDataFrame] = None,
     ):
         """Creates an MRM instance.
+
+        The dataset is processed for recourse using MRM.process_data(). This
+        processing step can be skipped by providing recourse data directly via
+        _processed_data. This is typically unnecessary for end users.
+
+        Data provided to _processed_data should
+            * Consist only of positively classified examples
+            * Not have the label column
+            * Be transformed into an embedded numerical space by the adapter.
 
         Args:
             dataset: The dataset to provide recourse over.
@@ -109,30 +121,56 @@ class MRM:
                 human-readable and embedded space.
             alpha: The alpha function to use during recourse generation.
             rescale_direction: A function for rescaling the recourse.
+            confidence_threshold: If provided, MRM only generates directions
+                pointing to areas of sufficiently high model confidence.
+            model: Used to check per-datapoint model confidence if
+                confidence_threshold is given.
+            _processed_data: A processed, recourse-ready dataset to use instead
+                of the provided dataset.
         """
-        self.data = MRM.process_data(dataset, adapter)
+        if _processed_data is not None:
+            self.data = _processed_data
+        else:
+            self.data = MRM._process_data(
+                dataset,
+                adapter,
+                confidence_threshold=confidence_threshold,
+                model=model,
+            )
         self.adapter = adapter
         self.alpha = alpha
         self.rescale_direction = rescale_direction
 
     @staticmethod
-    def process_data(
+    def _process_data(
         dataset: pd.DataFrame,
         adapter: recourse_adapter.RecourseAdapter,
+        confidence_threshold: Optional[float] = None,
+        model: Optional[model_interface.Model] = None,
     ) -> recourse_adapter.EmbeddedDataFrame:
         """Processes the dataset for MRM.
-        It filters out negative outcomes and transforms the data to a numeric
-        embedded space.
+
+        It filters out negative outcome points, drops the class label, and
+        transforms the data to a numeric embedded space. If
+        confidence_threshold is provided, it also filters out points which have
+        insufficient model confidence.
 
         Args:
             dataset: The dataset to process.
             adapter: The recourse adapter which transforms data to a numeric
                      embedded space.
+            confidence_threshold: If provided, filter out low-confidence ponts.
+            model: Used to find low-confidence points if confidence_threshold
+                is provided.
 
         Returns:
             A processed dataset.
         """
         positive_mask = dataset[adapter.label_column] == adapter.positive_label
+        if confidence_threshold:  # Only include "sufficiently" positive points
+            positive_mask = positive_mask & (
+                model.predict_pos_proba(dataset) > confidence_threshold
+            )
         positive_dataset = dataset[positive_mask]
         positive_embedded_dataset = adapter.transform(
             positive_dataset.drop(adapter.label_column, axis=1)
@@ -142,25 +180,6 @@ class MRM:
                 "Dataset is empty after excluding negative outcome examples."
             )
         return positive_embedded_dataset
-
-    # TODO(@jakeval): This should be reworked so it's harder to forget
-    def filter_data(
-        self, confidence_threshold: float, model: model_interface.Model
-    ) -> MRM:
-        """Filters the recourse dataset to include only high-confidence points.
-
-        Args:
-            confidence_threshold: All examples that do not achieve at least
-                                  this model confidence are removed.
-            model: The model to use for generating model confidence.
-
-        Returns:
-            Itself. The filtering is done mutably, so the returned version is
-            not a copy.
-        """
-        p = model.predict_proba(self.data)
-        self.data = self.data[p >= confidence_threshold]
-        return self
 
     def get_unnormalized_direction(
         self, poi: recourse_adapter.EmbeddedSeries
@@ -178,7 +197,7 @@ class MRM:
         diff = (self.data - poi).to_numpy()
         dist = np.sqrt(np.power(diff, 2).sum(axis=1))
         alpha_val = self.alpha(dist)
-        if alpha_val.isnull().any():
+        if np.isnan(alpha_val).any():
             raise RuntimeError(
                 f"Alpha function returned null values: {alpha_val}"
             )
@@ -248,8 +267,10 @@ class MRMC(RecourseMethod):
         adapter: recourse_adapter.RecourseAdapter,
         dataset: pd.DataFrame,
         alpha: AlphaFunction = get_volcano_alpha(),
-        rescale_direction: RecourseRescaler = normalize_rescaler,
-        clusters: Clusters = None,
+        rescale_direction: Optional[RecourseRescaler] = normalize_rescaler,
+        clusters: Optional[Clusters] = None,
+        confidence_threshold: Optional[float] = None,
+        model: Optional[model_interface.Model] = None,
     ):
         """Creates a new MRMC instance.
 
@@ -263,56 +284,45 @@ class MRMC(RecourseMethod):
             rescale_direction: The rescaling function each MRM should use.
             clusters: The cluster data to use. If None, performs k-means
                 clustering.
+            confidence_threshold: If provided, MRM only generates directions
+                pointing to areas of sufficiently high model confidence.
+            model: Used to check per-datapoint model confidence if
+                confidence_threshold is given.
         """
-        data = MRM.process_data(dataset, adapter)
+        data = MRM._process_data(
+            dataset,
+            adapter,
+            confidence_threshold=confidence_threshold,
+            model=model,
+        )
         self.k_directions = k_directions
         if not clusters:
-            clusters = self.cluster_data(data, self.k_directions)
+            clusters = MRMC._cluster_data(data, self.k_directions)
         self.clusters = clusters
-        self.validate_cluster_assignments(
+        MRMC._validate_cluster_assignments(
             clusters.cluster_assignments, self.k_directions
         )
 
         mrms = []
         for cluster_index in range(k_directions):
-            indices = clusters.cluster_assignments[
+            cluster_indices = clusters.cluster_assignments[
                 clusters.cluster_assignments["datapoint_cluster"]
                 == cluster_index
             ]["datapoint_index"]
-            data_cluster = data.loc[indices]
-            dataset_cluster = dataset.loc[data_cluster.index]
+            data_cluster = data.loc[cluster_indices]
             mrm = MRM(
-                dataset=dataset_cluster,
+                dataset=None,  # We provide _processed_data directly.
                 adapter=adapter,
                 alpha=alpha,
                 rescale_direction=rescale_direction,
+                _processed_data=data_cluster,
             )
             mrms.append(mrm)
         self.mrms: Sequence[MRM] = mrms
 
-    # TODO(@jakeval): Filtering should happen before clustering.
-    # TODO(@jakeval): Clarify this function name
-    def filter_data(
-        self, confidence_threshold: float, model: model_interface.Model
-    ) -> MRMC:
-        """Filters the recourse dataset to include only high-confidence points.
-
-        Args:
-            confidence_threshold: All examples that do not achieve at least
-                                  this model confidence are removed.
-            model: The model to use for generating model confidence.
-
-        Returns:
-            Itself. The filtering is done mutably, so the returned version is
-            not a copy.
-        """
-        for mrm in self.mrms:
-            mrm.filter_data(confidence_threshold, model)
-            return self
-
-    # TODO(@jakeval): Confidence check this
-    def cluster_data(
-        self, data: recourse_adapter.EmbeddedDataFrame, k_directions: int
+    @staticmethod
+    def _cluster_data(
+        data: recourse_adapter.EmbeddedDataFrame, k_directions: int
     ) -> Clusters:
         """Clusters the data using k-means clustering.
 
@@ -323,7 +333,7 @@ class MRMC(RecourseMethod):
             The data Clusters.
         """
         km = KMeans(n_clusters=k_directions)
-        cluster_assignments = km.fit_predict(data.to_numpy())
+        cluster_assignments = km.fit_predict(data)
         cluster_assignments = np.vstack(
             [data.index.to_numpy(), cluster_assignments]
         ).T
@@ -337,8 +347,9 @@ class MRMC(RecourseMethod):
             cluster_centers=cluster_centers,
         )
 
-    def validate_cluster_assignments(
-        self, cluster_assignments: pd.DataFrame, k_directions: int
+    @staticmethod
+    def _validate_cluster_assignments(
+        cluster_assignments: pd.DataFrame, k_directions: int
     ) -> bool:
         """Raises an error if the cluster_assignments is valid.
 

--- a/recourse_methods/test_mrmc_method.py
+++ b/recourse_methods/test_mrmc_method.py
@@ -110,8 +110,9 @@ class TestMRMC(unittest.TestCase):
             [1, 0.75 * -1 + 0.25 * 1], index=["a", "b"]
         )
         direction = mrmc_method.MRM.get_unnormalized_direction(mock_self, poi)
-        for val, expected_val in zip(direction, expected_direction):
-            self.assertEqual(val, expected_val)
+        np.testing.assert_equal(
+            direction.to_numpy(), expected_direction.to_numpy()
+        )
 
     def test_get_unnormalized_direction_nan_alpha(self):
         mock_self = mock.Mock(spec=["data", "alpha"])

--- a/recourse_methods/test_mrmc_method.py
+++ b/recourse_methods/test_mrmc_method.py
@@ -5,47 +5,41 @@ import pandas as pd
 from recourse_methods import mrmc_method
 
 
-SMALL_CUTOFF = 0.2
-LARGE_CUTOFF = 2
-DEGREE = 2
-volcano_alpha_large_cutoff = mrmc_method.get_volcano_alpha(
-    cutoff=LARGE_CUTOFF, degree=DEGREE
-)
-volcano_alpha_small_cutoff = mrmc_method.get_volcano_alpha(
-    cutoff=SMALL_CUTOFF, degree=DEGREE
-)
+_SMALL_CUTOFF = 0.2
+_LARGE_CUTOFF = 2
+_DEGREE = 2
 
 
 class TestMRMC(unittest.TestCase):
     def test_volcano_alpha_small_cutoff(self):
         distances = np.array([0, 1, 2, 3])
-        weights = volcano_alpha_small_cutoff(distances)
+        weights = mrmc_method.get_volcano_alpha(
+            cutoff=_SMALL_CUTOFF, degree=_DEGREE
+        )(distances)
         expected_weights = np.array(
             [
-                1 / (SMALL_CUTOFF**DEGREE),
-                1 / (1**DEGREE),
-                1 / (2**DEGREE),
-                1 / (3**DEGREE),
+                1 / (_SMALL_CUTOFF**_DEGREE),
+                1 / (1**_DEGREE),
+                1 / (2**_DEGREE),
+                1 / (3**_DEGREE),
             ]
         )
-
-        for val, expected_val in zip(weights, expected_weights):
-            self.assertAlmostEqual(val, expected_val)
+        np.testing.assert_almost_equal(weights, expected_weights)
 
     def test_volcano_alpha_large_cutoff(self):
         distances = np.array([0, 1, 2, 3])
-        weights = volcano_alpha_large_cutoff(distances)
+        weights = mrmc_method.get_volcano_alpha(
+            cutoff=_LARGE_CUTOFF, degree=_DEGREE
+        )(distances)
         expected_weights = np.array(
             [
-                1 / (LARGE_CUTOFF**DEGREE),
-                1 / (LARGE_CUTOFF**DEGREE),
-                1 / (2**DEGREE),
-                1 / (3**DEGREE),
+                1 / (_LARGE_CUTOFF**_DEGREE),
+                1 / (_LARGE_CUTOFF**_DEGREE),
+                1 / (2**_DEGREE),
+                1 / (3**_DEGREE),
             ]
         )
-
-        for val, expected_val in zip(weights, expected_weights):
-            self.assertAlmostEqual(val, expected_val)
+        np.testing.assert_almost_equal(weights, expected_weights)
 
     @mock.patch(
         "data.recourse_adapter.RecourseAdapter",

--- a/recourse_methods/test_mrmc_method.py
+++ b/recourse_methods/test_mrmc_method.py
@@ -58,13 +58,51 @@ class TestMRMC(unittest.TestCase):
         dataset = pd.DataFrame(
             {"col_1": [1, 2, 3], "col_2": [3, 5, 3], "label": [1, -1, 1]}
         )
-        processed_data = mrmc_method.MRM.process_data(dataset, mock_adapter)
+        processed_data = mrmc_method.MRM._process_data(dataset, mock_adapter)
         # The label should be dropped
         self.assertNotIn("label", processed_data.columns)
         # There should be no negative examples remaining
         negative_label_indices = (dataset[dataset.label == -1]).index
         self.assertEqual(
             0, len(processed_data.index.intersection(negative_label_indices))
+        )
+        # The transform function should be called
+        mock_adapter.transform.assert_called_once()
+
+    @mock.patch(
+        "data.recourse_adapter.RecourseAdapter",
+        autospec=True,
+    )
+    @mock.patch("models.model_interface.Model", autospec=True)
+    def test_process_data_confidence_threshold(
+        self, mock_model: mock.Mock, mock_adapter: mock.Mock
+    ):
+        mock_adapter.positive_label = 1
+        mock_adapter.label_column = "label"
+        mock_threshold = 0.7
+        mock_adapter.transform.side_effect = lambda df: df
+        dataset = pd.DataFrame(
+            {"col_1": [1, 2, 3], "col_2": [3, 5, 3], "label": [1, -1, 1]}
+        )
+        mock_confidences = pd.Series([0.8, 0.9, 0.6])
+        mock_model.predict_pos_proba.side_effect = [mock_confidences]
+        processed_data = mrmc_method.MRM._process_data(
+            dataset,
+            mock_adapter,
+            confidence_threshold=mock_threshold,
+            model=mock_model,
+        )
+        # The label should be dropped
+        self.assertNotIn("label", processed_data.columns)
+        # There should be no negative examples remaining
+        negative_label_indices = (dataset[dataset.label == -1]).index
+        self.assertEqual(
+            0, len(processed_data.index.intersection(negative_label_indices))
+        )
+        # There should be no low-confidence points
+        low_confidence_indices = [2]
+        self.assertEqual(
+            0, len(processed_data.index.intersection(low_confidence_indices))
         )
         # The transform function should be called
         mock_adapter.transform.assert_called_once()
@@ -88,3 +126,156 @@ class TestMRMC(unittest.TestCase):
         mock_self.alpha.side_effect = [pd.Series([np.nan, 0.25])]
         with self.assertRaises(RuntimeError):
             mrmc_method.MRM.get_unnormalized_direction(mock_self, poi)
+
+    @mock.patch("recourse_methods.mrmc_method.KMeans", autospec=True)
+    def test_cluster_data(self, mock_kmeans):
+        mock_data = pd.DataFrame({"a": range(7), "b": range(7)})
+        n_clusters = 3
+        expected_cluster_assignments = np.array([0, 0, 0, 1, 1, 2, 2])
+        expected_cluster_centers = "mock centers"
+        mock_kmeans().fit_predict.return_value = expected_cluster_assignments
+        mock_kmeans().cluster_centers_ = expected_cluster_centers
+
+        clusters = mrmc_method.MRMC._cluster_data(mock_data, n_clusters)
+
+        expected_cluster_assignment_df = pd.DataFrame(
+            {
+                "datapoint_index": range(7),
+                "datapoint_cluster": expected_cluster_assignments,
+            }
+        )
+
+        self.assertTrue(
+            (clusters.cluster_assignments == expected_cluster_assignment_df)
+            .all()
+            .all()
+        )
+        self.assertEqual(clusters.cluster_centers, expected_cluster_centers)
+        mock_kmeans.assert_called_with(n_clusters=n_clusters)
+
+    @mock.patch(
+        "recourse_methods.mrmc_method.MRM._process_data", autospec=True
+    )
+    @mock.patch(
+        "recourse_methods.mrmc_method.MRMC._cluster_data", autospec=True
+    )
+    @mock.patch(
+        "recourse_methods.mrmc_method.MRMC._validate_cluster_assignments",
+        autospec=True,
+    )
+    def test_mrmc_init(
+        self, mock_validate, mock_clustering, mock_process_data
+    ):
+        mock_dataset = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7], "b": [7, 6, 5, 4, 3, 2, 1]},
+            index=range(7),
+        )
+
+        # processing is a no-op
+        mock_process_data.return_value = mock_dataset
+
+        # assign clusters
+        mock_cluster_assignments = pd.DataFrame(
+            {
+                "datapoint_index": range(7),
+                "datapoint_cluster": [0, 0, 0, 1, 1, 2, 2],
+            }
+        )
+        mock_clusters = mrmc_method.Clusters(
+            cluster_assignments=mock_cluster_assignments, cluster_centers=None
+        )
+        mock_clustering.return_value = mock_clusters
+
+        mrmc = mrmc_method.MRMC(
+            k_directions=3,
+            adapter=None,
+            dataset=mock_dataset,
+            confidence_threshold=None,
+            model=None,
+        )
+
+        # Check that _process_data was called with correct arguments.
+        mock_process_data.assert_called_with(
+            mock_dataset,
+            None,
+            confidence_threshold=None,
+            model=None,
+        )
+
+        # Check that _cluster_data was called with filtered data.
+        mock_clustering.assert_called_with(mock_dataset, 3)
+
+        # Check that each MRM instance has the expected data indices.
+        expected_mrm_data_indices = [[0, 1, 2], [3, 4], [5, 6]]
+        for direction_index, mrm in enumerate(mrmc.mrms):
+            self.assertTrue(
+                (
+                    mrm.data.index
+                    == expected_mrm_data_indices[direction_index]
+                ).all()
+            )
+
+    @mock.patch(
+        "recourse_methods.mrmc_method.MRM._process_data", autospec=True
+    )
+    @mock.patch(
+        "recourse_methods.mrmc_method.MRMC._cluster_data", autospec=True
+    )
+    @mock.patch(
+        "recourse_methods.mrmc_method.MRMC._validate_cluster_assignments",
+        autospec=True,
+    )
+    def test_mrmc_init_confidence_threshold(
+        self, mock_validate, mock_clustering, mock_process_data
+    ):
+        mock_threshold = 0.6
+
+        mock_dataset = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7], "b": [7, 6, 5, 4, 3, 2, 1]},
+            index=range(7),
+        )
+
+        # Let data processing filter out indices 0 and 3
+        mock_processed_data = mock_dataset.iloc[[1, 2, 4, 5, 6]]
+        mock_process_data.return_value = mock_processed_data
+
+        # Assign clusters on remaining indices
+        mock_cluster_assignments = pd.DataFrame(
+            {
+                "datapoint_index": [1, 2, 4, 5, 6],
+                "datapoint_cluster": [0, 0, 1, 2, 2],
+            }
+        )
+        mock_clusters = mrmc_method.Clusters(
+            cluster_assignments=mock_cluster_assignments, cluster_centers=None
+        )
+        mock_clustering.return_value = mock_clusters
+
+        mrmc = mrmc_method.MRMC(
+            k_directions=3,
+            adapter=None,
+            dataset=mock_dataset,
+            confidence_threshold=mock_threshold,
+            model=None,
+        )
+
+        # Check that _process_data was called with correct arguments.
+        mock_process_data.assert_called_with(
+            mock_dataset,
+            None,
+            confidence_threshold=mock_threshold,
+            model=None,
+        )
+
+        # Check that _cluster_data was called with filtered data.
+        mock_clustering.assert_called_with(mock_processed_data, 3)
+
+        # Check that each MRM instance has the expected data indices.
+        expected_mrm_data_indices = [[1, 2], [4], [5, 6]]
+        for direction_index, mrm in enumerate(mrmc.mrms):
+            self.assertTrue(
+                (
+                    mrm.data.index
+                    == expected_mrm_data_indices[direction_index]
+                ).all()
+            )


### PR DESCRIPTION
Previously, processing data for recourse was handled clumsily between MRM and MRMC and made it difficult to get the correct order of operations between processing, filtering data points, and clustering. Processing and filtering data points has been altered and unit tests have been added to mrmc_method.py.

## Changelist
* filter_data() has been removed and is now part of MRM.process_data()
* Optional kwargs have been added to MRM and MRMC for adding confidence thresholds
* The private __init__ argument _processed_data was added to MRM so that it doesn't re-process data when initialized within MRMC
* unit tests were added to cover the changes

## Feedback requested
* Are the changes to filtering and data processing clear?
* Are the unit tests readable?
* Is there sufficient unit test coverage in mrmc_method.py?